### PR TITLE
replaced deprecated getDOMNode() with React.findDOMNode()

### DIFF
--- a/index.js
+++ b/index.js
@@ -33,7 +33,7 @@ module.exports = React.createClass({
   },
 
   handleClick: function handleClick(event) {
-    var checkbox = this.refs.input.getDOMNode();
+    var checkbox = React.findDOMNode(this.refs.input);
     var checkboxWasDirectlyClicked = event.target === checkbox;
     if (checkboxWasDirectlyClicked) {
       return;
@@ -56,7 +56,7 @@ module.exports = React.createClass({
       return this.props.checked;
     }
     if (this.refs.input) {
-      return this.refs.input.getDOMNode().checked;
+      return React.findDOMNode(this.refs.input).checked;
     }
     return this.props.defaultChecked || false;
   },

--- a/index.js
+++ b/index.js
@@ -33,7 +33,7 @@ module.exports = React.createClass({
   },
 
   handleClick: function handleClick(event) {
-    var checkbox = this.refs.input.getDOMNode();
+    var checkbox = React.findDOMNode(this.refs.input.getDOMNode);
     var checkboxWasDirectlyClicked = event.target === checkbox;
     if (checkboxWasDirectlyClicked) {
       return;
@@ -56,7 +56,7 @@ module.exports = React.createClass({
       return this.props.checked;
     }
     if (this.refs.input) {
-      return this.refs.input.getDOMNode().checked;
+      return React.findDOMNode(this.refs.input).checked;
     }
     return this.props.defaultChecked || false;
   },


### PR DESCRIPTION
Hi!

According to React docs [here](https://facebook.github.io/react/docs/component-api.html) getDOMNode() is deprecated.  Easy fix.
