### PR TITLE
Fix broken link to the CSS in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ See [usage and examples](http://instructure-react.github.io/react-toggle/).
 npm install react-toggle
 ```
 
-Include the component's [CSS](https://raw.githubusercontent.com/instructure-react/react-toggle/master/example/styles.css).
+Include the component's [CSS](./style.css).
 
 ## Development
 


### PR DESCRIPTION
It seems the CSS file was removed from the example folder in ea1346a
This commit makes that link point to the one in the root directory.

Also, it is not recommended to use absolute URLs in READMEs:
https://help.github.com/articles/relative-links-in-readmes/
