### PR TITLE
adding 'disabled' and 'hasFocus' to propTypes; add documentation for props to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,46 @@ An elegant, accessible toggle component for React. Also a glorified checkbox.
 
 See [usage and examples](http://instructure-react.github.io/react-toggle/).
 
+## Props
+
+The component takes the following props.
+
+- `checked`: _bool_
+> If `true`, the toggle is checked. If `false`, the toggle is unchecked.
+	Use this if you want to treat the toggle as a controlled component
+
+- `defaultChecked`: _bool_
+> If `true` on initial render, the toggle is checked.
+	If `false` on initial render, the toggle is unchecked.
+	Use this if you want to treat the toggle as an uncontrolled component
+
+- `onChange`: _function_
+> Callback function to invoke when the user clicks on the toggle.
+	The function signature should be the following: ```js function(e) { }```.
+	To get the current checked status from the event, use `e.target.checked`.
+
+- `name`: _string_
+> The value of the `name` attribute of the wrapped \<input\> element
+
+- `value`: _string_
+> The value of the `value` attribute of the wrapped \<input\> element
+
+- `id`: _string_
+> The value of the `id` attribute of the wrapped \<input\> element
+
+- `aria-labelledby`: _string_
+> The value of the `aria-labelledby` attribute of the wrapped \<input\> element
+
+- `aria-label`: _string_
+> The value of the `aria-label` attribute of the wrapped \<input\> element
+
+- `disabled`: _bool_
+> If `true`, the toggle is enabled. If `false`, the toggle is disabled
+
+- `hasFocus`: _bool_
+> If `true`, the toggle is focused. If `false`, the toggle does not have focus
+
+
 ## Installation
 
 ```bash

--- a/index.js
+++ b/index.js
@@ -29,9 +29,7 @@ module.exports = React.createClass({
     value: React.PropTypes.string,
     id: React.PropTypes.string,
     "aria-labelledby": React.PropTypes.string,
-    "aria-label": React.PropTypes.string,
-    disabled: React.PropTypes.bool,
-    hasFocus: React.PropTypes.bool
+    "aria-label": React.PropTypes.string
   },
 
   getInitialState: function getInitialState() {

--- a/index.js
+++ b/index.js
@@ -29,7 +29,9 @@ module.exports = React.createClass({
     value: React.PropTypes.string,
     id: React.PropTypes.string,
     "aria-labelledby": React.PropTypes.string,
-    "aria-label": React.PropTypes.string
+    "aria-label": React.PropTypes.string,
+    disabled: React.PropTypes.bool,
+    hasFocus: React.PropTypes.bool
   },
 
   getInitialState: function getInitialState() {


### PR DESCRIPTION
To Whomever It May Concern,

First wanted to start off by saying thank you for creating this awesome component!

This PR addresses the following:
- Adds `disabled` and `hasFocus` to propTypes
- Adds documentation for the props to the README document

Let me know if you have any questions/comments.

Thanks!
- Rohit K
