### PR TITLE
Update package for React 0.14 compatibiltiy

### DIFF
--- a/example/index.js
+++ b/example/index.js
@@ -1,4 +1,5 @@
 import React from 'react'
+import { render } from 'react-dom'
 
 import Toggle from '../index.es6'
 // In your code this would be:
@@ -39,7 +40,7 @@ var App = React.createClass({
   },
 
   handleMilkChange(event) {
-    var form = this.refs.breakfastForm.getDOMNode()
+    var form = this.refs.breakfastForm
     this.setState({formData: form.milkIsReady.checked ? {milkIsReady: form.milkIsReady.value} : {}})
   },
 
@@ -285,4 +286,4 @@ var App = React.createClass({
   }
 })
 
-React.render(<App />, document.getElementById('application'))
+render(<App />, document.getElementById('application'))

--- a/index.es6.js
+++ b/index.es6.js
@@ -2,9 +2,7 @@ import React from 'react'
 import classNames from 'classnames'
 import Check from './check'
 import X from './x'
-import {addons} from 'react/addons'
-
-var PureRenderMixin = addons.PureRenderMixin;
+import PureRenderMixin from 'react-addons-pure-render-mixin'
 
 export default React.createClass({
   mixins: [PureRenderMixin],
@@ -42,7 +40,7 @@ export default React.createClass({
   },
 
   handleClick(event) {
-    var checkbox = React.findDOMNode(this.refs.input)
+    var checkbox = this.refs.input
     if (event.target !== checkbox)
     {
       event.preventDefault()

--- a/package.json
+++ b/package.json
@@ -30,12 +30,14 @@
     "babel-loader": "^4.2.0",
     "css-loader": "^0.9.1",
     "mocha": "^2.2.1",
-    "react": "^0.13.0",
+    "react": "^0.14.0",
+    "react-dom": "^0.14.0",
     "style-loader": "^0.9.0",
     "webpack": "^1.7.3",
     "webpack-dev-server": "^1.7.0"
   },
   "dependencies": {
-    "classnames": "^1.2.0"
+    "classnames": "^1.2.0",
+    "react-addons-pure-render-mixin": "^0.14.0"
   }
 }


### PR DESCRIPTION
Most of the changes relate to the splitting out of react-dom and addons from the core library, as well as DOM access patterns (e.g. no more getDOMNode for refs). It should be noted that this introduces `react-addons-pure-render-mixin` as a new dependency, but leaves the `react-dom` dependency up to the user (the same as the dependency on `react`).

Full release notes can be found here: https://facebook.github.io/react/blog/2015/10/07/react-v0.14.html

I've tested these changes with everything in `examples` – please let me know if there's any more formal testing that isn't documented or anything.
