### PR TITLE
fix fill-rule attribute name

### DIFF
--- a/check.es6.js
+++ b/check.es6.js
@@ -7,7 +7,7 @@ export default React.createClass({
         <title>
           switch-check
         </title>
-        <path d="M11.264 0L5.26 6.004 2.103 2.847 0 4.95l5.26 5.26 8.108-8.107L11.264 0" fill="#fff" fill-rule="evenodd"/>
+        <path d="M11.264 0L5.26 6.004 2.103 2.847 0 4.95l5.26 5.26 8.108-8.107L11.264 0" fill="#fff" fillRule="evenodd"/>
       </svg>
     )
   }

--- a/check.js
+++ b/check.js
@@ -16,7 +16,7 @@ module.exports = React.createClass({
         null,
         "switch-check"
       ),
-      React.createElement("path", { d: "M11.264 0L5.26 6.004 2.103 2.847 0 4.95l5.26 5.26 8.108-8.107L11.264 0", fill: "#fff", "fill-rule": "evenodd" })
+      React.createElement("path", { d: "M11.264 0L5.26 6.004 2.103 2.847 0 4.95l5.26 5.26 8.108-8.107L11.264 0", fill: "#fff", fillRule: "evenodd" })
     );
   }
 });

--- a/x.es6.js
+++ b/x.es6.js
@@ -7,7 +7,7 @@ export default React.createClass({
         <title>
           switch-x
         </title>
-        <path d="M9.9 2.12L7.78 0 4.95 2.828 2.12 0 0 2.12l2.83 2.83L0 7.776 2.123 9.9 4.95 7.07 7.78 9.9 9.9 7.776 7.072 4.95 9.9 2.12" fill="#fff" fill-rule="evenodd"/>
+        <path d="M9.9 2.12L7.78 0 4.95 2.828 2.12 0 0 2.12l2.83 2.83L0 7.776 2.123 9.9 4.95 7.07 7.78 9.9 9.9 7.776 7.072 4.95 9.9 2.12" fill="#fff" fillRule="evenodd"/>
       </svg>
     )
   }

--- a/x.js
+++ b/x.js
@@ -16,7 +16,7 @@ module.exports = React.createClass({
         null,
         "switch-x"
       ),
-      React.createElement("path", { d: "M9.9 2.12L7.78 0 4.95 2.828 2.12 0 0 2.12l2.83 2.83L0 7.776 2.123 9.9 4.95 7.07 7.78 9.9 9.9 7.776 7.072 4.95 9.9 2.12", fill: "#fff", "fill-rule": "evenodd" })
+      React.createElement("path", { d: "M9.9 2.12L7.78 0 4.95 2.828 2.12 0 0 2.12l2.83 2.83L0 7.776 2.123 9.9 4.95 7.07 7.78 9.9 9.9 7.776 7.072 4.95 9.9 2.12", fill: "#fff", fillRule: "evenodd" })
     );
   }
 });


### PR DESCRIPTION
React warns about incorrect attribute name and discards the "fill-rule" attribute.
