### PR TITLE
adding react as peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,6 +40,6 @@
     "react-addons-pure-render-mixin": ">=0.14.0"
   },
   "peerDependencies": {
-    "react": "^0.14.0 || ^15.0.0-0",
+    "react": "^0.14.0 || ^15.0.0-0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -30,7 +30,6 @@
     "babel-loader": "^4.2.0",
     "css-loader": "^0.9.1",
     "mocha": "^2.2.1",
-    "react": "*",
     "react-dom": ">=0.14.0",
     "style-loader": "^0.9.0",
     "webpack": "^1.7.3",
@@ -39,5 +38,8 @@
   "dependencies": {
     "classnames": "~2.2",
     "react-addons-pure-render-mixin": ">=0.14.0"
+  },
+  "peerDependencies": {
+    "react": "^0.14.0 || ^15.0.0-0",
   }
 }


### PR DESCRIPTION
It seems all the other major libraries are defining react as a peerDependency. I'm having some issues with `15.2.0`, but since react-toggle is defining a dependency: `"react": "*",`. It isn't possible for me to be on a specific version of react.

This is my first PR (ever), but this seems like a logical step.

Let me know if I'm way off base.
