### PR TITLE
Remove broken syntax highlighting attempt from README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ The component takes the following props.
 
 - `onChange`: _function_
 > Callback function to invoke when the user clicks on the toggle.
-	The function signature should be the following: ```js function(e) { }```.
+	The function signature should be the following: `function(e) { }`.
 	To get the current checked status from the event, use `e.target.checked`.
 
 - `name`: _string_


### PR DESCRIPTION
Specifying a language doesn't work for inline code. This seemed like the better alternative to creating a code block.
