### PR TITLE
Customizable toggle renderer

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,3 +1,4 @@
 {
-  "presets": ["es2015", "react"]
+  "presets": ["es2015", "react"],
+  "plugins": ["transform-object-rest-spread"]
 }

--- a/README.md
+++ b/README.md
@@ -25,6 +25,10 @@ The component takes the following props.
 - `name`: _string_
 > The value of the `name` attribute of the wrapped \<input\> element
 
+- `toggleRenderer`: _function_
+> A method `function({checked, disabled, }) => React.Element` which overrides the default toggle renderer.
+  Returns the custom React element to be rendered as the toggle.
+
 - `value`: _string_
 > The value of the `value` attribute of the wrapped \<input\> element
 

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "babel-cli": "^6.14.0",
     "babel-core": "^6.14.0",
     "babel-loader": "^6.2.5",
+    "babel-plugin-transform-object-rest-spread": "^6.16.0",
     "babel-preset-es2015": "^6.14.0",
     "babel-preset-react": "^6.11.1",
     "copy-webpack-plugin": "^3.0.1",

--- a/src/component/index.js
+++ b/src/component/index.js
@@ -41,31 +41,25 @@ export default class Toggle extends Component {
   }
 
   render () {
-    var classes = classNames('react-toggle', {
-      'react-toggle--checked': this.state.checked,
-      'react-toggle--focus': this.state.hasFocus,
-      'react-toggle--disabled': this.props.disabled
+    const {toggleRenderer, disabled, ...otherProps} = this.props;
+    const {checked, hasFocus} = this.state;
+    const inputProps = {...otherProps, disabled};
+    const classes = classNames('react-toggle', {
+      'react-toggle--checked': checked,
+      'react-toggle--focus': hasFocus,
+      'react-toggle--disabled': disabled
     })
 
     return (
       <div className={classes} onClick={this.handleClick}>
-        <div className='react-toggle-track'>
-          <div className='react-toggle-track-check'>
-            <Check />
-          </div>
-          <div className='react-toggle-track-x'>
-            <X />
-          </div>
-        </div>
-        <div className='react-toggle-thumb' />
-
+        {toggleRenderer({checked, disabled, hasFocus})}
         <input
           ref={ref => { this.input = ref }}
           onFocus={this.handleFocus}
           onBlur={this.handleBlur}
           className='react-toggle-screenreader-only'
           type='checkbox'
-          {...this.props} />
+          {...inputProps} />
       </div>
     )
   }
@@ -79,8 +73,27 @@ Toggle.propTypes = {
   defaultChecked: PropTypes.bool,
   onChange: PropTypes.func,
   name: PropTypes.string,
+  toggleRenderer: PropTypes.func,
   value: PropTypes.string,
   id: PropTypes.string,
   'aria-labelledby': PropTypes.string,
   'aria-label': PropTypes.string
+}
+
+Toggle.defaultProps = {
+  toggleRenderer: () => {
+    return (
+      <div>
+        <div className='react-toggle-track'>
+          <div className='react-toggle-track-check'>
+            <Check />
+          </div>
+          <div className='react-toggle-track-x'>
+            <X />
+          </div>
+        </div>
+        <div className='react-toggle-thumb' />
+      </div>
+    );
+  }
 }

--- a/src/docs/index.js
+++ b/src/docs/index.js
@@ -1,5 +1,6 @@
 import React, { Component } from 'react'
 import { render } from 'react-dom'
+import classnames from 'classnames';
 
 import Toggle from '../component'
 // In your code this would be:
@@ -7,6 +8,28 @@ import Toggle from '../component'
 
 import '../../style.css'
 import './style.css'
+
+function customToggleRenderer({checked, disabled}) {
+  const trackClassName = classnames('track-custom', {
+    'track-custom--checked': checked,
+    'track-custom--unchecked': !checked
+  });
+  const thumbClassName = classnames('thumb-custom', {
+    'thumb-custom--checked': checked,
+    'thumb-custom--unchecked': !checked
+  });
+  const toggleClassName = classnames({'disabled-custom': disabled});
+
+  return (
+    <div className={toggleClassName}>
+      <div className={trackClassName}>
+        <div className="check-custom"/>
+        <div className="x-custom"/>
+      </div>
+      <div className={thumbClassName}/>
+    </div>
+  );
+}
 
 class App extends Component {
   constructor (props) {
@@ -269,6 +292,64 @@ class App extends Component {
           </pre>
         </div>
 
+      {/* Customize Style */}
+
+        <div className='example'>
+          <div style={{marginBottom: '8px'}}>
+            <label>
+              <Toggle
+                defaultChecked
+                toggleRenderer={customToggleRenderer} />
+                <span className='label-text'>Custom toggle renderer</span>
+            </label>
+          </div>
+          <div>
+            <label>
+              <Toggle
+                disabled={true}
+                toggleRenderer={customToggleRenderer} />
+                <span className='label-text'>Custom toggle renderer, disabled</span>
+            </label>
+          </div>
+          <pre>
+            {`/*
+function customToggleRenderer({checked, disabled}) {
+  const trackClassName = classnames('track-custom', {
+    'track-custom--checked': checked,
+    'track-custom--unchecked': !checked
+  });
+  const thumbClassName = classnames('thumb-custom', {
+    'thumb-custom--checked': checked,
+    'thumb-custom--unchecked': !checked
+  });
+  const toggleClassName = classnames({'disabled-custom': disabled});
+
+  return (
+    <div className={toggleClassName}>
+      <div className={trackClassName}>
+        <div className="check-custom"/>
+        <div className="x-custom"/>
+      </div>
+      <div className={thumbClassName}/>
+    </div>
+  );
+}
+*/
+
+<label>
+  <Toggle
+    defaultChecked
+    toggleRenderer={customToggleRenderer} />
+    <span className='label-text'>Customized toggle renderer</span>
+</label>
+<label>
+  <Toggle
+    disabled={true}
+    toggleRenderer={customToggleRenderer} />
+    <span className='label-text'>Custom toggle renderer, disabled</span>
+</label>`}
+          </pre>
+        </div>
       </form>
     )
   }

--- a/src/docs/style.css
+++ b/src/docs/style.css
@@ -20,3 +20,74 @@ label,
 pre {
   margin-top: 8px;
 }
+
+.track-custom {
+  width: 63px;
+  height: 32px;
+  padding: 0;
+  border-radius: 16px;
+
+  -webkit-transition: all 0.2s ease;
+  -moz-transition: all 0.2s ease;
+  transition: all 0.2s ease;
+}
+
+.track-custom--checked {
+  background-color: #19AB27;
+}
+
+.track-custom--unchecked {
+  background-color: #4D4D4D;
+}
+
+.thumb-custom {
+  transition: all 0.5s cubic-bezier(0.23, 1, 0.32, 1) 0ms;
+  position: absolute;
+  top: 1px;
+  width: 30px;
+  height: 30px;
+  border: 1px solid #4D4D4D;
+  border-radius: 50%;
+  background: #FEFEFE;
+
+  -webkit-box-sizing: border-box;
+  -moz-box-sizing: border-box;
+  box-sizing: border-box;
+
+  -webkit-transition: all 0.25s ease;
+  -moz-transition: all 0.25s ease;
+  transition: all 0.25s ease;
+}
+
+.thumb-custom--checked {
+  left: 32px;
+  border-color: #19AB27;
+}
+
+.thumb-custom--unchecked {
+  left: 1px;
+}
+
+.check-custom, .x-custom {
+  font-size: 10px;
+  color: #FEFEFE;
+}
+
+.check-custom::before, .x-custom::before {
+  position: absolute;
+  top: 8px;
+}
+
+.check-custom::before {
+  content: 'YES';
+  left: 10px;
+}
+
+.x-custom {
+  color: #FEFEFE;
+}
+
+.x-custom::before {
+  content: 'NO';
+  right: 10px;
+}

--- a/src/docs/style.css
+++ b/src/docs/style.css
@@ -33,7 +33,7 @@ pre {
 }
 
 .track-custom--checked {
-  background-color: #19AB27;
+  background-color: #129bcf;
 }
 
 .track-custom--unchecked {
@@ -61,7 +61,7 @@ pre {
 
 .thumb-custom--checked {
   left: 32px;
-  border-color: #19AB27;
+  border-color: #129bcf;
 }
 
 .thumb-custom--unchecked {
@@ -90,4 +90,8 @@ pre {
 .x-custom::before {
   content: 'NO';
   right: 10px;
+}
+
+.disabled-custom {
+  opacity: 0.5;
 }


### PR DESCRIPTION
Enables using a custom toggle renderer for overriding the default toggle style.

While the component currently offers a nice default style, usually users want to customize the toggle styles to conform with their use case. While users could overwrite the global styles offered in the package, some users would without a doubt like to use for example CSS modules to style their components instead of using/overwriting global styles. When building with Webpack the style import order is also not always determinable, which may lead into a case where the original styles actually override some custom styles unless the custom rules are annotated with CSS's `!important`.

Enabling passing a custom toggle renderer method allows for the most flexibility without having to e.g. define props for each toggle element's class separately.

![image](https://cloud.githubusercontent.com/assets/861353/19235149/87a39a8e-8ef8-11e6-8a57-176ea6420c27.png)
