### PR TITLE
Add touch/swipe support

### DIFF
--- a/src/component/index.js
+++ b/src/component/index.js
@@ -71,13 +71,17 @@ export default class Toggle extends Component {
     if (this.startX) {
       let endX = pointerCoord(event).x
       if (this.previouslyChecked === true && this.startX + 4 > endX) {
-        this.setState({ checked: false })
-        this.previouslyChecked = this.state.checked
-        checkbox.click()
+        if (this.previouslyChecked !== this.state.checked) {
+          this.setState({ checked: false })
+          this.previouslyChecked = this.state.checked
+          checkbox.click()
+        }
       } else if (this.startX - 4 < endX) {
-        this.setState({ checked: true })
-        this.previouslyChecked = this.state.checked
-        checkbox.click()
+        if (this.previouslyChecked !== this.state.checked) {
+          this.setState({ checked: true })
+          this.previouslyChecked = this.state.checked
+          checkbox.click()
+        }
       }
 
       this.activated = false

--- a/src/component/util.js
+++ b/src/component/util.js
@@ -1,0 +1,20 @@
+// Copyright 2015-present Drifty Co.
+// http://drifty.com/
+// from: https://github.com/driftyco/ionic/blob/master/src/util/dom.ts
+
+export function pointerCoord (event) {
+  // get coordinates for either a mouse click
+  // or a touch depending on the given event
+  if (event) {
+    const changedTouches = event.changedTouches
+    if (changedTouches && changedTouches.length > 0) {
+      const touch = changedTouches[0]
+      return { x: touch.clientX, y: touch.clientY }
+    }
+    const pageX = event.pageX
+    if (pageX !== undefined) {
+      return { x: pageX, y: event.pageY }
+    }
+  }
+  return { x: 0, y: 0 }
+}


### PR DESCRIPTION
Hi all,

This pull request adds touch specific functionality. It enables the user to swipe and drag the toggle switch back and forth as is expected on touch devices. It should work for both controlled/uncontrolled uses of this component.

The util function is borrowed from the smart people working on the Ionic project. The touch specific implementation also borrows a lot from theirs: https://github.com/driftyco/ionic/blob/master/src/components/toggle/toggle.ts

During user testing, we discovered that the majority of users were confused by the toggle switch on mobile devices. They would try and drag the toggle which wouldn't work. This addition aims to solve that.

The example below shows me clicking on the toggle, clicking on the label wrapping the toggle, and dragging the toggle switch back and forth.

This was recorded using an iOS simulator; usually, mouse users won't be able to drag the toggle back and forth.

![toggle](https://cloud.githubusercontent.com/assets/540048/20691975/b872a8d2-b589-11e6-9cd7-fded82d2175b.gif)

I would love feedback on this. Please test it and try to break it.

I haven't added unit tests yet for the new functionality. I'm pretty strapped for time right now so it would be _greatly_ appreciated if someone wanted to jump in and write some tests for this.