### PR TITLE
feature(check-icon): now can set icon on the thumb

### DIFF
--- a/src/component/check.js
+++ b/src/component/check.js
@@ -1,10 +1,10 @@
 import React from 'react'
 
 export default () => (
-  <svg width='14' height='11' viewBox='0 0 14 11'>
+  <svg width='14' height='11' viewBox='0 0 14 11' >
     <title>
       switch-check
     </title>
-    <path d='M11.264 0L5.26 6.004 2.103 2.847 0 4.95l5.26 5.26 8.108-8.107L11.264 0' fill='#fff' fillRule='evenodd' />
+    <path d='M11.264 0L5.26 6.004 2.103 2.847 0 4.95l5.26 5.26 8.108-8.107L11.264 0' fill='#fff' fillRule='evenodd' className='react-toggle-thumb-icon' />
   </svg>
 )

--- a/src/component/index.js
+++ b/src/component/index.js
@@ -130,6 +130,22 @@ export default class Toggle extends PureComponent {
       'react-toggle--disabled': this.props.disabled,
     }, className)
 
+    const isIconOnThumb = _icons && _icons.thumb
+
+    const checked = this.getIcon('checked')
+    const unchecked = this.getIcon('unchecked')
+
+    const track = !isIconOnThumb && (
+      <div>
+        <div className='react-toggle-track-check'>
+          {checked}
+        </div>
+        <div className='react-toggle-track-x'>
+          {unchecked}
+        </div>
+      </div>
+    )
+
     return (
       <div className={classes}
         onClick={this.handleClick}
@@ -137,14 +153,11 @@ export default class Toggle extends PureComponent {
         onTouchMove={this.handleTouchMove}
         onTouchEnd={this.handleTouchEnd}>
         <div className='react-toggle-track'>
-          <div className='react-toggle-track-check'>
-            {this.getIcon('checked')}
-          </div>
-          <div className='react-toggle-track-x'>
-            {this.getIcon('unchecked')}
-          </div>
+          {track}
         </div>
-        <div className='react-toggle-thumb' />
+        <div className='react-toggle-thumb'>
+          {isIconOnThumb && (this.state.checked ? checked : unchecked)}
+        </div>
 
         <input
           {...inputProps}

--- a/src/component/x.js
+++ b/src/component/x.js
@@ -5,6 +5,6 @@ export default () => (
     <title>
       switch-x
     </title>
-    <path d='M9.9 2.12L7.78 0 4.95 2.828 2.12 0 0 2.12l2.83 2.83L0 7.776 2.123 9.9 4.95 7.07 7.78 9.9 9.9 7.776 7.072 4.95 9.9 2.12' fill='#fff' fillRule='evenodd' />
+    <path d='M9.9 2.12L7.78 0 4.95 2.828 2.12 0 0 2.12l2.83 2.83L0 7.776 2.123 9.9 4.95 7.07 7.78 9.9 9.9 7.776 7.072 4.95 9.9 2.12' fill='#fff' fillRule='evenodd' className='react-toggle-thumb-icon' />
   </svg>
 )

--- a/src/docs/index.js
+++ b/src/docs/index.js
@@ -363,6 +363,28 @@ class App extends Component {
           </pre>
         </div>
 
+        {/* thumb icons */}
+
+        <div className='example'>
+          <label>
+            <Toggle
+              defaultChecked={this.state.tofuIsReady}
+              icons={{ thumb: true }}
+              onChange={this.handleTofuChange} />
+            <span className='label-text'>Thumb Icons</span>
+          </label>
+
+          <pre>
+            {`<label>
+  <Toggle
+    defaultChecked={this.state.tofuIsReady}
+    icons={{ thumb: true }}
+    onChange={this.handleTofuChange} />
+  <span>Thumb Icons</span>
+</label>`}
+          </pre>
+        </div>
+
       </form>
     )
   }

--- a/style.css
+++ b/style.css
@@ -121,6 +121,30 @@
   -webkit-transition: all 0.25s ease;
   -moz-transition: all 0.25s ease;
   transition: all 0.25s ease;
+
+  text-align: center;
+}
+
+.react-toggle-thumb {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+
+.react-toggle-thumb .react-toggle-thumb-icon {
+  fill: #4D4D4D
+}
+
+.react-toggle:hover:not(.react-toggle--disabled) .react-toggle-thumb .react-toggle-thumb-icon {
+  fill: #000000;
+}
+
+.react-toggle--checked .react-toggle-thumb .react-toggle-thumb-icon {
+  fill: #19AB27;
+}
+
+.react-toggle--checked:hover:not(.react-toggle--disabled) .react-toggle-thumb .react-toggle-thumb-icon {
+  fill: #128D15;
 }
 
 .react-toggle--checked .react-toggle-thumb {


### PR DESCRIPTION
fix this issue -> [FEATURE REQUEST]: can set icons on toggle handler #80

add `thumb` flag in prop `icons` can move **check & uncheck** mark to the thumb.

![thumb-icon](https://cloud.githubusercontent.com/assets/929878/22013305/af899c84-dcdb-11e6-9c8d-009bc49f1646.gif)

@aaronshaf hope this could be merge.