### PR TITLE
NPM install should --save not --save-dev

### DIFF
--- a/src/docs/index.js
+++ b/src/docs/index.js
@@ -67,7 +67,7 @@ class App extends Component {
         <div className='example'>
           <div>Installation</div>
           <pre>
-            {`npm install react-toggle --save-dev`}
+            {`npm install react-toggle --save`}
           </pre>
           <pre>{`import Toggle from 'react-toggle'`}</pre>
           <p>Or if you're not using the ES6 module format yet:</p>


### PR DESCRIPTION
If someone is using your awesome module, they're likely going to need it bundled in their build, --save will mean it's saved in the correct part of their package.json