### PR TITLE
Update PeerDependencies and upgrade minor version to prevent broken builds

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-toggle",
-  "version": "2.2.1",
+  "version": "2.3.0",
   "description": "An elegant, accessible toggle component for React. Also a glorified checkbox.",
   "main": "dist/component/index.js",
   "style": "src/style.css",
@@ -60,7 +60,7 @@
     "classnames": "^2.2.5"
   },
   "peerDependencies": {
-    "react": "~0.14.0 || ^15.0.0",
-    "react-dom": "~0.14.0 || ^15.0.0"
+    "react": "^15.3.0",
+    "react-dom": "^15.3.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-toggle",
-  "version": "2.3.0",
+  "version": "3.0.0",
   "description": "An elegant, accessible toggle component for React. Also a glorified checkbox.",
   "main": "dist/component/index.js",
   "style": "src/style.css",


### PR DESCRIPTION
The use of React PureComponent in commit bcb0d78422388a573477d497409f2b92ce39e5fa caused the peer dependencies to no longer satisfy the packages needs. PureComponent was added in React version 15.3. To prevent build failures for people who use version 0.14, we needed to fix the package.json peer dependencies.

I properly fixed the peerDependancies and also upgraded the package version. Will need to be deployed to NPM, as I don't have permissions to deploy.