### PR TITLE
Fix: controlled component gets toggled on first click #85

### DIFF
--- a/src/component/index.js
+++ b/src/component/index.js
@@ -35,8 +35,10 @@ export default class Toggle extends PureComponent {
       checkbox.click()
       return
     }
+    
+    const checked = this.props.hasOwnProperty('checked') ? this.props.checked : checkbox.checked;
 
-    this.setState({checked: checkbox.checked})
+    this.setState({checked})
   }
 
   handleTouchStart (event) {


### PR DESCRIPTION
I haven't tested this for touch events but this solves #85 issue for onClick events for me.