### PR TITLE
Don't use deprecated React.PropTypes API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ as of release version 2.1.0.
 - Don't react on hover when disabled
 - Fix issue with broken React ref
 - Fix lint errors
+- Don't use deprecated `React.PropTypes` API
 
 
 ## [2.1.1] - 2016-07-13

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
   },
   "peerDependencies": {
     "react": "^15.3.0",
-    "react-dom": "^15.3.0"
+    "react-dom": "^15.3.0",
+    "prop-types": "^15.3.0"
   }
 }

--- a/src/component/index.js
+++ b/src/component/index.js
@@ -1,5 +1,6 @@
-import React, { PureComponent, PropTypes } from 'react'
+import React, { PureComponent } from 'react'
 import classNames from 'classnames'
+import PropTypes from 'prop-types'
 import Check from './check'
 import X from './x'
 import { pointerCoord } from './util'


### PR DESCRIPTION
Clears the path for React 16.0.0 and avoids the deprecation warning for React 15.5.0.