### PR TITLE
Add onFocus / onBlur props support

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ The component takes the following props.
 | `checked`         | _boolean_  | If `true`, the toggle is checked. If `false`, the toggle is unchecked. Use this if you want to treat the toggle as a controlled component |
 | `defaultChecked`  | _boolean_  | If `true` on initial render, the toggle is checked. If `false` on initial render, the toggle is unchecked. Use this if you want to treat the toggle as an uncontrolled component |
 | `onChange`        | _function_ | Callback function to invoke when the user clicks on the toggle. The function signature should be the following: `function(e) { }`. To get the current checked status from the event, use `e.target.checked`. |
+| `onFocus`         | _function_ | Callback function to invoke when field has focus. The function signature should be the following: `function(e) { }` |
+| `onBlur`          | _function_ | Callback function to invoke when field loses focus. The function signature should be the following: `function(e) { }` |
 | `name`            | _string_   | The value of the `name` attribute of the wrapped \<input\> element |
 | `value`           | _string_   | The value of the `value` attribute of the wrapped \<input\> element |
 | `id`              | _string_   | The value of the `id` attribute of the wrapped \<input\> element |

--- a/src/component/index.js
+++ b/src/component/index.js
@@ -12,8 +12,8 @@ export default class Toggle extends PureComponent {
     this.handleTouchStart = this.handleTouchStart.bind(this)
     this.handleTouchMove = this.handleTouchMove.bind(this)
     this.handleTouchEnd = this.handleTouchEnd.bind(this)
-    this.handleFocus = this.setState.bind(this, { hasFocus: true }, () => {})
-    this.handleBlur = this.setState.bind(this, { hasFocus: false }, () => {})
+    this.handleFocus = this.handleFocus.bind(this)
+    this.handleBlur = this.handleBlur.bind(this)
     this.previouslyChecked = !!(props.checked || props.defaultChecked)
     this.state = {
       checked: !!(props.checked || props.defaultChecked),
@@ -90,6 +90,26 @@ export default class Toggle extends PureComponent {
     }
   }
 
+  handleFocus (event) {
+    const { onFocus } = this.props
+
+    if (onFocus) {
+      onFocus(event)
+    }
+
+    this.setState({ hasFocus: true })
+  }
+
+  handleBlur (event) {
+    const { onBlur } = this.props
+
+    if (onBlur) {
+      onBlur(event)
+    }
+
+    this.setState({ hasFocus: false })
+  }
+
   getIcon (type) {
     const { icons } = this.props
     if (!icons) {
@@ -150,6 +170,8 @@ Toggle.propTypes = {
   disabled: PropTypes.bool,
   defaultChecked: PropTypes.bool,
   onChange: PropTypes.func,
+  onFocus: PropTypes.func,
+  onBlur: PropTypes.func,
   className: PropTypes.string,
   name: PropTypes.string,
   value: PropTypes.string,


### PR DESCRIPTION
This change adds support for passing `onFocus` / `onBlur` callbacks as props.

```javascript
import Toggle from 'react-toggle'

const CustomToggle = (props) => {
    const onFocus = () => {
        console.log('onFocus')
    }

    const onBlur = () => {
        console.log('onBlur')
    }

    return (<Toggle onFocus={onFocus} onBlur={onBlur} {...props} />)
}
```
