### PR TITLE
CSS touch-action: pan-x improves dragging with some browsers

### DIFF
--- a/style.css
+++ b/style.css
@@ -1,4 +1,6 @@
 .react-toggle {
+  touch-action: pan-x;
+
   display: inline-block;
   position: relative;
   cursor: pointer;


### PR DESCRIPTION
Limiting the `touch-action` style to `pan-x` improves the touch-drag experience with some browser versions. Certainly doesn't hurt with any other browser.