### PR TITLE
Added Test cases:-

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "build-component": "babel src/component --out-dir dist/component",
     "build-docs": "webpack",
     "build": "npm run build-component && npm run build-docs",
-    "test": "mocha --require babel-register --require spec/setup.js spec/**/*.spec.js",
+    "test": "nyc mocha --require babel-register --require spec/setup.js spec/**/*.spec.js",
     "lint": "eslint .; exit 0",
     "dev": "webpack-dev-server"
   },
@@ -50,6 +50,7 @@
     "eslint-plugin-standard": "^2.0.1",
     "jsdom": "^9.6.0",
     "mocha": "^3.1.2",
+    "nyc": "^11.0.2",
     "react": "^15.3.1",
     "react-dom": "^15.3.1",
     "style-loader": "^0.13.1",

--- a/spec/component.spec.js
+++ b/spec/component.spec.js
@@ -2,7 +2,14 @@ import React from 'react'
 import chai, { expect } from 'chai'
 import chaiEnzyme from 'chai-enzyme'
 import Toggle from '../src/component'
-import { shallow } from 'enzyme'
+import { shallow, mount } from 'enzyme'
+import TestUtils from 'react-dom/test-utils'
+
+const {
+  findRenderedDOMComponentWithTag,
+  findRenderedDOMComponentWithClass,
+  Simulate,
+} = TestUtils
 
 const noop = () => {}
 const classNames = {
@@ -135,5 +142,115 @@ describe('Component', () => {
     expect(wrapper.hasClass(classNames.focus)).to.be.true
     expect(wrapper.hasClass(classNames.checked)).to.be.true
     expect(wrapper.hasClass(classNames.disabled)).to.be.false
+  })
+
+  it('tests toggle on click', () => {
+    wrapper = mount(
+      <Toggle
+        onChange={noop} />
+    )
+
+    expect(wrapper.find('input')).to.not.be.checked()
+    wrapper.find('.react-toggle').simulate('click')
+    expect(wrapper.find('input')).to.be.checked()
+    wrapper.find('.react-toggle').simulate('click')
+    expect(wrapper.find('input')).to.not.be.checked()
+  })
+
+  it('tests onChange callback', () => {
+    let called = false
+    const changeHandler = () => {
+      called = true
+      return
+    }
+    wrapper = mount(
+      <Toggle
+        onChange={changeHandler} />
+    )
+    const input = findRenderedDOMComponentWithTag(wrapper.node, 'input')
+    expect(called).to.equal(false)
+    Simulate.change(input)
+    expect(called).to.equal(true)
+  })
+
+  it('tests onBlur callback', () => {
+    let called = false
+    const blurHandler = () => {
+      called = true
+      return
+    }
+    const wrapper = mount(
+      <Toggle
+        onChange={noop}
+        onBlur={blurHandler} />
+    )
+    const input = findRenderedDOMComponentWithTag(wrapper.node, 'input')
+    expect(called).to.equal(false)
+    Simulate.blur(input)
+    expect(called).to.equal(true)
+  })
+
+  it('tests onFocus callback', () => {
+    let called = false
+    const focusHandler = () => {
+      called = true
+      return
+    }
+    const wrapper = mount(
+      <Toggle
+        onChange={noop}
+        onFocus={focusHandler} />
+    )
+    const input = findRenderedDOMComponentWithTag(wrapper.node, 'input')
+    expect(called).to.equal(false)
+    Simulate.focus(input)
+    expect(called).to.equal(true)
+  })
+
+  it('tests toggle on touch with default unchecked', () => {
+    const wrapper = mount(
+      <Toggle
+        defaultChecked={false}
+        onChange={noop} />
+    )
+    const toggleComp = findRenderedDOMComponentWithClass(wrapper.node, 'react-toggle')
+    expect(wrapper.find('input')).to.not.be.checked()
+    Simulate.touchStart(toggleComp, {changedTouches: [ {clientX: 30, clientY: 30} ]})
+    Simulate.touchMove(toggleComp, {changedTouches: [ {clientX: 55, clientY: 30} ]})
+    Simulate.touchEnd(toggleComp, {changedTouches: [ {clientX: 55, clientY: 30} ]})
+    expect(wrapper.find('input')).to.be.checked()
+  })
+
+  it('tests toggle on touch with default checked', () => {
+    const wrapper = mount(
+      <Toggle
+        defaultChecked
+        onChange={noop} />
+    )
+    const toggleComp = findRenderedDOMComponentWithClass(wrapper.node, 'react-toggle')
+    expect(wrapper.find('input')).to.be.checked()
+    Simulate.touchStart(toggleComp, {changedTouches: [ {clientX: 55, clientY: 30} ]})
+    Simulate.touchMove(toggleComp, {changedTouches: [ {clientX: 30, clientY: 30} ]})
+    Simulate.touchEnd(toggleComp, {changedTouches: [ {clientX: 30, clientY: 30} ]})
+    expect(wrapper.find('input')).to.not.be.checked()
+  })
+
+  it('tests toggle on touch with pageXY', () => {
+    const wrapper = mount(
+      <Toggle
+        defaultChecked={false}
+        onChange={noop} />
+    )
+    const toggleComp = findRenderedDOMComponentWithClass(wrapper.node, 'react-toggle')
+
+    expect(wrapper.find('input')).to.not.be.checked()
+    Simulate.touchStart(toggleComp, {changedTouches: [], pageX: 30, pageY: 30})
+    Simulate.touchMove(toggleComp, {changedTouches: [], pageX: 55, pageY: 30})
+    Simulate.touchEnd(toggleComp, {changedTouches: [], pageX: 55, pageY: 30})
+    expect(wrapper.find('input')).to.be.checked()
+    Simulate.touchStart(toggleComp, {changedTouches: [], pageX: 55, pageY: 30})
+    Simulate.touchMove(toggleComp, {changedTouches: [], pageX: 30, pageY: 30})
+    Simulate.touchEnd(toggleComp, {changedTouches: [], pageX: 30, pageY: 30})
+    expect(wrapper.find('input')).to.not.be.checked()
   })
 })

--- a/src/component/index.js
+++ b/src/component/index.js
@@ -36,8 +36,8 @@ export default class Toggle extends PureComponent {
       checkbox.click()
       return
     }
-    
-    const checked = this.props.hasOwnProperty('checked') ? this.props.checked : checkbox.checked;
+
+    const checked = this.props.hasOwnProperty('checked') ? this.props.checked : checkbox.checked
 
     this.setState({checked})
   }


### PR DESCRIPTION
 * Test cases:-

1. toggle on click
2. callback handlers for focus, blur, change
3. toggle on touch

* Added test coverage with nyc istanbul (I can remove this if you want, but it shows the coverage more clearly)

* Removed extra semicolon which was causing lint to throw (i just encountered this when running lint before creating the PR)

* Test coverage before and after-
<img width="1221" alt="screen shot 2017-06-04 at 4 30 54 pm" src="https://cloud.githubusercontent.com/assets/28827885/26761144/ead73cbe-4947-11e7-84c6-584ab045a88d.png">
<img width="1232" alt="screen shot 2017-06-04 at 4 32 06 pm" src="https://cloud.githubusercontent.com/assets/28827885/26761152/052f4002-4948-11e7-86b4-80c626541c48.png">
