### PR TITLE
Slim down NPM package

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,7 +1,0 @@
-.babelrc
-.eslintrc.json
-.eslintignore
-docs/
-spec/
-src/
-webpack.config.js

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "dist/component/index.js",
   "style": "src/style.css",
   "scripts": {
-    "prepublish": "npm run build && cp -rv dist/docs/* docs/",
+    "prepublish": "npm run build",
     "build-component": "babel src/component --out-dir dist/component",
     "build-docs": "webpack",
     "build": "npm run build-component && npm run build-docs",
@@ -29,6 +29,10 @@
     "url": "https://github.com/aaronshaf/react-toggle/issues"
   },
   "license": "MIT",
+  "files": [
+    "dist",
+    "style.css"
+  ],
   "devDependencies": {
     "babel-cli": "^6.14.0",
     "babel-core": "^6.14.0",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -6,7 +6,7 @@ module.exports = {
   devtool: 'source-map',
 
   output: {
-    path: path.join(__dirname, 'dist/docs'),
+    path: path.join(__dirname, 'docs'),
     filename: 'bundle.js',
   },
 
@@ -25,7 +25,7 @@ module.exports = {
   },
 
   devServer: {
-    contentBase: path.join(__dirname, 'dist/docs'),
+    contentBase: path.join(__dirname, 'docs'),
     host: 'localhost',
     inline: true,
     info: false,


### PR DESCRIPTION
This PR slims down the NPM package by removing the docs and any additional development config files. See http://blog.npmjs.org/post/165769683050/publishing-what-you-mean-to-publish for reasoning.

```
$ npm pack
react-toggle-4.0.2.tgz

$ tar tvf react-toggle-4.0.2.tgz 
-rw-rw-r-- 1000/1000      2105 2017-10-15 13:01 package/package.json
-rw-rw-r-- 1000/1000      2926 2017-10-15 12:56 package/README.md
-rw-rw-r-- 1000/1000      1085 2017-10-15 12:56 package/LICENSE
-rw-rw-r-- 1000/1000       652 2017-10-15 13:01 package/dist/component/check.js
-rw-rw-r-- 1000/1000      9018 2017-10-15 13:01 package/dist/component/index.js
-rw-rw-r-- 1000/1000       722 2017-10-15 13:01 package/dist/component/util.js
-rw-rw-r-- 1000/1000       696 2017-10-15 13:01 package/dist/component/x.js
-rw-rw-r-- 1000/1000      1440 2017-10-15 12:56 package/CHANGELOG.md
-rw-rw-r-- 1000/1000      3021 2017-10-15 12:56 package/style.css

```