### PR TITLE
Add divProps property applying to the wrapper div

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ The component takes the following props.
 | `aria-labelledby` | _string_   | The value of the `aria-labelledby` attribute of the wrapped \<input\> element |
 | `aria-label`      | _string_   | The value of the `aria-label` attribute of the wrapped \<input\> element |
 | `disabled`        | _boolean_  | If `true`, the toggle is disabled. If `false`, the toggle is enabled |
+| `divProps`        | _object_  | An object of properties to apply to the wrapping \<div\> element instead of the \<input\> element. |
 
 ## Installation
 

--- a/src/component/index.js
+++ b/src/component/index.js
@@ -123,7 +123,7 @@ export default class Toggle extends PureComponent {
   }
 
   render () {
-    const { className, icons: _icons, ...inputProps } = this.props
+    const { className, icons: _icons, divProps, ...inputProps } = this.props
     const classes = classNames('react-toggle', {
       'react-toggle--checked': this.state.checked,
       'react-toggle--focus': this.state.hasFocus,
@@ -131,7 +131,9 @@ export default class Toggle extends PureComponent {
     }, className)
 
     return (
-      <div className={classes}
+      <div
+        {...divProps}
+        className={classes}
         onClick={this.handleClick}
         onTouchStart={this.handleTouchStart}
         onTouchMove={this.handleTouchMove}
@@ -165,6 +167,7 @@ Toggle.defaultProps = {
     checked: <Check />,
     unchecked: <X />,
   },
+  divProps: {},
 }
 
 Toggle.propTypes = {
@@ -187,4 +190,5 @@ Toggle.propTypes = {
       unchecked: PropTypes.node,
     }),
   ]),
+  divProps: PropTypes.shape({}),
 }


### PR DESCRIPTION
I wanted to put first a `style` property on the wrapping div, then I was surprised to find that `title` didn't work, so I thought it best to handle a general case and allow developers to put whatever properties they like on the div.