### PR TITLE
Bug: align icons relative to toggle track.

### DIFF
--- a/style.css
+++ b/style.css
@@ -43,6 +43,7 @@
   padding: 0;
   border-radius: 30px;
   background-color: #4D4D4D;
+  position: relative;
   -webkit-transition: all 0.2s ease;
   -moz-transition: all 0.2s ease;
   transition: all 0.2s ease;


### PR DESCRIPTION
I noticed a small bug that the icons were not correctly aligned when the label text ran to multiple lines:
![image](https://user-images.githubusercontent.com/5547470/48673522-20757800-eb3a-11e8-8432-248dc262fd64.png)

This appears to be because the icons were treating `react-toggle` as their [containing block](https://developer.mozilla.org/en-US/docs/Web/CSS/Containing_block) instead of `react-toggle-track`.

Setting the `react-toggle-track` to `position: relative` causes it to be treated as a the containing block and appears to fix the problem:

![image](https://user-images.githubusercontent.com/5547470/48673605-f96b7600-eb3a-11e8-8126-4b92eb1d1c9b.png)
