### PR TITLE
Remove the switch SVG title tags

### DIFF
--- a/src/component/check.js
+++ b/src/component/check.js
@@ -2,9 +2,6 @@ import React from 'react'
 
 export default () => (
   <svg width='14' height='11' viewBox='0 0 14 11'>
-    <title>
-      switch-check
-    </title>
     <path d='M11.264 0L5.26 6.004 2.103 2.847 0 4.95l5.26 5.26 8.108-8.107L11.264 0' fill='#fff' fillRule='evenodd' />
   </svg>
 )

--- a/src/component/x.js
+++ b/src/component/x.js
@@ -2,9 +2,6 @@ import React from 'react'
 
 export default () => (
   <svg width='10' height='10' viewBox='0 0 10 10'>
-    <title>
-      switch-x
-    </title>
     <path d='M9.9 2.12L7.78 0 4.95 2.828 2.12 0 0 2.12l2.83 2.83L0 7.776 2.123 9.9 4.95 7.07 7.78 9.9 9.9 7.776 7.072 4.95 9.9 2.12' fill='#fff' fillRule='evenodd' />
   </svg>
 )


### PR DESCRIPTION
These SVG titles are announced by VoiceOver on Safari, but are meaningless to screenreader users, and invisible to sighted users