### PR TITLE
Fix disabled toggle touch

### DIFF
--- a/spec/component.spec.js
+++ b/spec/component.spec.js
@@ -256,4 +256,23 @@ describe('Component', () => {
     Simulate.touchEnd(toggleComp, { changedTouches: [], pageX: 30, pageY: 30 })
     expect(wrapper.find('input')).to.not.be.checked()
   })
+
+  it('does not toggle on touch when disabled', () => {
+    const wrapper = mount(<Toggle disabled defaultChecked={false} onChange={noop} />)
+    const toggleComp = findRenderedDOMComponentWithClass(
+      wrapper.node,
+      'react-toggle'
+    )
+    expect(wrapper.find('input')).to.not.be.checked()
+    Simulate.touchStart(toggleComp, {
+      changedTouches: [{ clientX: 30, clientY: 30 }],
+    })
+    Simulate.touchMove(toggleComp, {
+      changedTouches: [{ clientX: 55, clientY: 30 }],
+    })
+    Simulate.touchEnd(toggleComp, {
+      changedTouches: [{ clientX: 55, clientY: 30 }],
+    })
+    expect(wrapper.find('input')).to.not.be.checked()
+  })
 })

--- a/src/component/index.js
+++ b/src/component/index.js
@@ -28,6 +28,9 @@ export default class Toggle extends PureComponent {
 	}
 
   handleClick (event) {
+    if (this.props.disabled) {
+      return
+    }
     const checkbox = this.input
     if (event.target !== checkbox && !this.moved) {
       this.previouslyChecked = checkbox.checked
@@ -43,6 +46,9 @@ export default class Toggle extends PureComponent {
   }
 
   handleTouchStart (event) {
+    if (this.props.disabled) {
+      return
+    }
     this.startX = pointerCoord(event).x
     this.activated = true
   }


### PR DESCRIPTION
In both Firefox and Chrome with touch enabled (both on desktop and mobile) I'm able to toggle toggleswitches even on disabled toggles.

The first commit adds what was supposed to be a failing test, but the test passes (false negative). I am not sure why.

The second commit returns from the handleClick and handleTouchStart functions if the control is disabled. This fixes the bug for me in manual tests. (And the faulty test still passes.)