### PR TITLE
Add a readOnly prop

### DIFF
--- a/spec/component.spec.js
+++ b/spec/component.spec.js
@@ -17,6 +17,7 @@ const classNames = {
   focus: 'react-toggle--focus',
   checked: 'react-toggle--checked',
   disabled: 'react-toggle--disabled',
+  readOnly: 'react-toggle--read-only',
 }
 
 chai.use(chaiEnzyme())
@@ -124,24 +125,48 @@ describe('Component', () => {
     expect(wrapper.hasClass(classNames.focus)).to.be.false
     expect(wrapper.hasClass(classNames.checked)).to.be.false
     expect(wrapper.hasClass(classNames.disabled)).to.be.false
+    expect(wrapper.hasClass(classNames.readOnly)).to.be.false
 
     wrapper.setState({ checked: true, hasFocus: false })
     expect(wrapper.hasClass(classNames.base)).to.be.true
     expect(wrapper.hasClass(classNames.focus)).to.be.false
     expect(wrapper.hasClass(classNames.checked)).to.be.true
     expect(wrapper.hasClass(classNames.disabled)).to.be.false
+    expect(wrapper.hasClass(classNames.readOnly)).to.be.false
 
     wrapper.setState({ checked: false, hasFocus: true })
     expect(wrapper.hasClass(classNames.base)).to.be.true
     expect(wrapper.hasClass(classNames.focus)).to.be.true
     expect(wrapper.hasClass(classNames.checked)).to.be.false
     expect(wrapper.hasClass(classNames.disabled)).to.be.false
+    expect(wrapper.hasClass(classNames.readOnly)).to.be.false
 
     wrapper.setState({ checked: true, hasFocus: true })
     expect(wrapper.hasClass(classNames.base)).to.be.true
     expect(wrapper.hasClass(classNames.focus)).to.be.true
     expect(wrapper.hasClass(classNames.checked)).to.be.true
     expect(wrapper.hasClass(classNames.disabled)).to.be.false
+    expect(wrapper.hasClass(classNames.readOnly)).to.be.false
+  })
+
+  it('uses correct classNames based on props', () => {
+    wrapper = shallow(<Toggle />)
+
+    wrapper.setProps({ disabled: false, readOnly: false })
+    expect(wrapper.hasClass(classNames.disabled)).to.be.false
+    expect(wrapper.hasClass(classNames.readOnly)).to.be.false
+
+    wrapper.setProps({ disabled: true, readOnly: false })
+    expect(wrapper.hasClass(classNames.disabled)).to.be.true
+    expect(wrapper.hasClass(classNames.readOnly)).to.be.false
+
+    wrapper.setProps({ disabled: false, readOnly: true })
+    expect(wrapper.hasClass(classNames.disabled)).to.be.false
+    expect(wrapper.hasClass(classNames.readOnly)).to.be.true
+
+    wrapper.setProps({ disabled: true, readOnly: true })
+    expect(wrapper.hasClass(classNames.disabled)).to.be.true
+    expect(wrapper.hasClass(classNames.readOnly)).to.be.true
   })
 
   it('tests toggle on click', () => {
@@ -273,6 +298,33 @@ describe('Component', () => {
     Simulate.touchEnd(toggleComp, {
       changedTouches: [{ clientX: 55, clientY: 30 }],
     })
+    expect(wrapper.find('input')).to.not.be.checked()
+  })
+
+  it('does not toggle on touch when read-only', () => {
+    const wrapper = mount(<Toggle readOnly defaultChecked={false} onChange={noop} />)
+    const toggleComp = findRenderedDOMComponentWithClass(
+      wrapper.node,
+      'react-toggle'
+    )
+    expect(wrapper.find('input')).to.not.be.checked()
+    Simulate.touchStart(toggleComp, {
+      changedTouches: [{ clientX: 30, clientY: 30 }],
+    })
+    Simulate.touchMove(toggleComp, {
+      changedTouches: [{ clientX: 55, clientY: 30 }],
+    })
+    Simulate.touchEnd(toggleComp, {
+      changedTouches: [{ clientX: 55, clientY: 30 }],
+    })
+    expect(wrapper.find('input')).to.not.be.checked()
+  })
+
+  it('does not toggle on click when read-only', () => {
+    wrapper = mount(<Toggle readOnly onChange={noop} />)
+
+    expect(wrapper.find('input')).to.not.be.checked()
+    wrapper.find('.react-toggle').simulate('click')
     expect(wrapper.find('input')).to.not.be.checked()
   })
 })

--- a/spec/component.spec.js
+++ b/spec/component.spec.js
@@ -256,4 +256,23 @@ describe('Component', () => {
     Simulate.touchEnd(toggleComp, { changedTouches: [], pageX: 30, pageY: 30 })
     expect(wrapper.find('input')).to.not.be.checked()
   })
+
+  it('does not toggle on touch when disabled', () => {
+    const wrapper = mount(<Toggle disabled defaultChecked={false} onChange={noop} />)
+    const toggleComp = findRenderedDOMComponentWithClass(
+      wrapper.node,
+      'react-toggle'
+    )
+    expect(wrapper.find('input')).to.not.be.checked()
+    Simulate.touchStart(toggleComp, {
+      changedTouches: [{ clientX: 30, clientY: 30 }],
+    })
+    Simulate.touchMove(toggleComp, {
+      changedTouches: [{ clientX: 55, clientY: 30 }],
+    })
+    Simulate.touchEnd(toggleComp, {
+      changedTouches: [{ clientX: 55, clientY: 30 }],
+    })
+    expect(wrapper.find('input')).to.not.be.checked()
+  })
 })

--- a/src/component/index.js
+++ b/src/component/index.js
@@ -28,7 +28,7 @@ export default class Toggle extends PureComponent {
 	}
 
   handleClick (event) {
-    if (this.props.disabled) {
+    if (this.props.disabled || this.props.readOnly) {
       return
     }
     const checkbox = this.input
@@ -46,7 +46,7 @@ export default class Toggle extends PureComponent {
   }
 
   handleTouchStart (event) {
-    if (this.props.disabled) {
+    if (this.props.disabled || this.props.readOnly) {
       return
     }
     this.startX = pointerCoord(event).x
@@ -134,6 +134,7 @@ export default class Toggle extends PureComponent {
       'react-toggle--checked': this.state.checked,
       'react-toggle--focus': this.state.hasFocus,
       'react-toggle--disabled': this.props.disabled,
+      'react-toggle--read-only': this.props.readOnly,
     }, className)
 
     return (
@@ -176,6 +177,7 @@ Toggle.defaultProps = {
 Toggle.propTypes = {
   checked: PropTypes.bool,
   disabled: PropTypes.bool,
+  readOnly: PropTypes.bool,
   defaultChecked: PropTypes.bool,
   onChange: PropTypes.func,
   onFocus: PropTypes.func,

--- a/src/component/index.js
+++ b/src/component/index.js
@@ -28,6 +28,9 @@ export default class Toggle extends PureComponent {
 	}
 
   handleClick (event) {
+    if (this.props.disabled) {
+      return
+    }
     const checkbox = this.input
     if (event.target !== checkbox && !this.moved) {
       this.previouslyChecked = checkbox.checked
@@ -43,6 +46,9 @@ export default class Toggle extends PureComponent {
   }
 
   handleTouchStart (event) {
+    if (this.props.disabled) {
+      return
+    }
     this.startX = pointerCoord(event).x
     this.activated = true
   }

--- a/src/docs/index.js
+++ b/src/docs/index.js
@@ -314,6 +314,39 @@ class App extends Component {
           </pre>
         </div>
 
+        {/* Read-only */}
+
+        <div className='example'>
+          <div style={{ marginBottom: '8px' }}>
+            <label>
+              <Toggle defaultChecked={false} readOnly />
+              <span className='label-text'>Read-only, Unchecked</span>
+            </label>
+          </div>
+
+          <div>
+            <label>
+              <Toggle defaultChecked readOnly />
+              <span className='label-text'>Read-only, Checked</span>
+            </label>
+          </div>
+
+          <pre>
+            {`<label>
+  <Toggle
+    defaultChecked={false}
+    readOnly={true} />
+  <span className='label-text'>Read-only, Unchecked</span>
+</label>
+<label>
+  <Toggle
+    defaultChecked={true}
+    readOnly={true} />
+  <span className='label-text'>Read-only, Checked</span>
+</label>`}
+          </pre>
+        </div>
+
         {/* Custom className */}
 
         <div className='example'>

--- a/style.css
+++ b/style.css
@@ -30,7 +30,8 @@
   width: 1px;
 }
 
-.react-toggle--disabled {
+.react-toggle--disabled,
+.react-toggle--read-only {
   cursor: not-allowed;
   opacity: 0.5;
   -webkit-transition: opacity 0.25s;


### PR DESCRIPTION
The HTML input element's `readonly` attribute is different from the `disabled` attribute: a read-only control and its contents will still be visible (to everyone, including screen reader users) and will still submit its value along with the form.

I wasn't sure how to style this. I decided at least for now to style it the same as "disabled" in terms of transparency and the "not-allowed" cursor, but still allow focus etc.

This PR is based on https://github.com/aaronshaf/react-toggle/pull/154 since it touches some of the same code. As a result, the same gotcha I mentioned in that PR is present here: the tests for not being able to change a toggle via touch when it's disabled or read-only *pass* when the code preventing this is *disabled*, i.e. they will not correctly detect a regression.