### PR TITLE
Update redirect URL to component styles

### DIFF
--- a/src/docs/index.js
+++ b/src/docs/index.js
@@ -87,7 +87,7 @@ class App extends Component {
           <pre>{`var Toggle = require('react-toggle')`}</pre>
           <p>
             Include the component's{' '}
-            <a href='https://raw.githubusercontent.com/instructure-react/react-toggle/master/style.css'>
+            <a href='https://github.com/aaronshaf/react-toggle#usage'>
               CSS
             </a>
             .


### PR DESCRIPTION
The URL pointing to the raw CSS file was misleading in my case because I thought all I had to do was to create a `toggle.module.css` file and import that in the component I was using `<Toggle />` which took me a while to debug.