### PR TITLE
feat: Allow React 18 as peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,8 +62,8 @@
     "classnames": "^2.2.5"
   },
   "peerDependencies": {
-    "prop-types": ">= 15.3.0 < 18",
-    "react": ">= 15.3.0 < 18",
-    "react-dom": ">= 15.3.0 < 18"
+    "prop-types": ">= 15.3.0 < 19",
+    "react": ">= 15.3.0 < 19",
+    "react-dom": ">= 15.3.0 < 19"
   }
 }


### PR DESCRIPTION
Update peerDependency for made it compatible with react 18

friendly ping @aaronshaf @tremby

All tests pass:
<img width="595" alt="image" src="https://user-images.githubusercontent.com/12977575/169020777-fde6bed4-b3d2-4d7a-aeeb-2d5e126498ff.png">
