### PR TITLE
Add label to toggle's input for accessibility

### DIFF
--- a/src/component/index.js
+++ b/src/component/index.js
@@ -155,7 +155,11 @@ export default class Toggle extends PureComponent {
           </div>
         </div>
         <div className='react-toggle-thumb' />
-
+        {inputProps.id && (
+          <label className='react-toggle-screenreader-only' htmlFor={inputProps.id}>
+            React-toggle checkbox. Screenreader only
+          </label>
+        )}
         <input
           {...inputProps}
           ref={ref => { this.input = ref }}


### PR DESCRIPTION
When running Web vitals test on a web page using react-toggle, the test complains that there's no accompanying label to the input. 

You could surround the Toggle component with a label tag, but it messes up with the styling.

I am talking of cases where you don't need any visible label (before the toggle for instance).

This PR just add a label tag, with the already existing css class "react-toggle-screenreader-only"; before the input element when an id prop is specified. This is done to improve the library accessibility. 

Thank you !